### PR TITLE
Add Formula for jsonschema CLI (fixes Linux install failure)

### DIFF
--- a/Formula/jsonschema.rb
+++ b/Formula/jsonschema.rb
@@ -1,0 +1,62 @@
+class Jsonschema < Formula
+  desc "The CLI for working with JSON Schema"
+  homepage "https://github.com/sourcemeta/jsonschema"
+  version "14.14.2"
+  license "AGPL-3.0-only"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/sourcemeta/jsonschema/releases/download/v#{version}/jsonschema-#{version}-darwin-arm64.zip"
+      sha256 "ae73b90e79a7e587f05d722de502b31eeb701b072e2563c38d717388a5c6e785"
+
+      def install
+        dir = "jsonschema-#{version}-darwin-arm64"
+        bin.install "#{dir}/bin/jsonschema"
+        bash_completion.install "#{dir}/share/bash-completion/completions/jsonschema"
+        zsh_completion.install "#{dir}/share/zsh/site-functions/_jsonschema"
+      end
+    end
+
+    on_intel do
+      url "https://github.com/sourcemeta/jsonschema/releases/download/v#{version}/jsonschema-#{version}-darwin-x86_64.zip"
+      sha256 "dc6b99a44a1e9d002e7c534cec452fe351ae63791dfdd65e147a327c64974d51"
+
+      def install
+        dir = "jsonschema-#{version}-darwin-x86_64"
+        bin.install "#{dir}/bin/jsonschema"
+        bash_completion.install "#{dir}/share/bash-completion/completions/jsonschema"
+        zsh_completion.install "#{dir}/share/zsh/site-functions/_jsonschema"
+      end
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/sourcemeta/jsonschema/releases/download/v#{version}/jsonschema-#{version}-linux-arm64.zip"
+      sha256 "cb8fd293ead5bb68be931d23b81c8d2278d047defb91b27e2d2892704211c198"
+
+      def install
+        dir = "jsonschema-#{version}-linux-arm64"
+        bin.install "#{dir}/bin/jsonschema"
+        bash_completion.install "#{dir}/share/bash-completion/completions/jsonschema"
+        zsh_completion.install "#{dir}/share/zsh/site-functions/_jsonschema"
+      end
+    end
+
+    on_intel do
+      url "https://github.com/sourcemeta/jsonschema/releases/download/v#{version}/jsonschema-#{version}-linux-x86_64.zip"
+      sha256 "6473ee098c77d93afa15f4237c6e0fd2ce6cf3105d00ddb097cad1cf8b2f368e"
+
+      def install
+        dir = "jsonschema-#{version}-linux-x86_64"
+        bin.install "#{dir}/bin/jsonschema"
+        bash_completion.install "#{dir}/share/bash-completion/completions/jsonschema"
+        zsh_completion.install "#{dir}/share/zsh/site-functions/_jsonschema"
+      end
+    end
+  end
+
+  test do
+    system "#{bin}/jsonschema", "--version"
+  end
+end


### PR DESCRIPTION
## Summary

Fixes: sourcemeta/jsonschema#683

The existing `Casks/jsonschema.rb` only supplies `arm:`/`intel:` SHA-256
keys, which are macOS-centric. On Linux those keys evaluate to `nil` and
Homebrew immediately rejects the cask with:

```
Error: Cask 'jsonschema' definition is invalid: invalid 'sha256' value: nil
```

## Solution

Add `Formula/jsonschema.rb` — a proper Homebrew formula that uses
`on_macos`/`on_linux` + `on_arm`/`on_intel` blocks, covering all four
supported platform/architecture combinations from the v14.14.2 release:

| Platform | Arch | Asset |
|---|---|---|
| macOS | arm64 | `jsonschema-{version}-darwin-arm64.zip` |
| macOS | x86_64 | `jsonschema-{version}-darwin-x86_64.zip` |
| Linux | arm64 | `jsonschema-{version}-linux-arm64.zip` |
| Linux | x86_64 | `jsonschema-{version}-linux-x86_64.zip` |

The formula also installs bash and zsh shell completions (already bundled in
each zip archive) and includes a smoke-test block (`jsonschema --version`).

The existing `Casks/jsonschema.rb` is left in place for backwards-compat;
once this formula is confirmed working it can be removed in a follow-up PR.

## Testing

On Linux x86_64:
```sh
brew tap sourcemeta/apps
brew install --formula sourcemeta/apps/jsonschema
jsonschema --version
```